### PR TITLE
Add ability to inject link tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ export default {
       sourcemap: false,
       // inject `@import` directives
       injectImports: false,
+      // 'link' will rewrite the JavaScript bundle to inject link tags that load the CSS
+      injectType: null,
       // name pattern for emitted secondary chunks
       chunkFileNames: '[name]-[hash].css',
       // name pattern for emitted entry chunks

--- a/index.ts
+++ b/index.ts
@@ -5,10 +5,35 @@ import {
     OutputBundle,
     OutputChunk,
     PluginContext,
-    PluginImpl
+    PluginImpl,
+    RenderedChunk
 } from 'rollup';
 import {createFilter} from 'rollup-pluginutils';
 import {encode, decode} from 'sourcemap-codec';
+
+interface SourceMap {
+    mappings: string,
+    sources: string[],
+    sourcesContent: string
+}
+
+interface PluginOptions {
+    injectImports: boolean;
+    injectType: 'link' | null;
+    ignore: boolean;
+    sourcemap: boolean;
+    chunkFileNames: string;
+    entryFileNames: string;
+}
+
+interface InputPluginOptions {
+    injectImports?: boolean;
+    injectType?: 'link' | null;
+    ignore?: boolean;
+    sourcemap?: boolean;
+    chunkFileNames?: string;
+    entryFileNames?: string;
+}
 
 function hash(content: string) {
     return crypto.createHmac('sha256', content)
@@ -20,33 +45,70 @@ function makeFileName(name: string, hashed: string, pattern: string) {
     return pattern.replace('[name]', name).replace('[hash]', hashed);
 }
 
-interface SourceMap {
-    mappings: string,
-    sources: string[],
-    sourcesContent: string
-}
+const INJECT_STYLES_NAME = 'inject_styles';
+const INJECT_STYLES_ID = 'inject_styles.js';
 
-interface PluginOptions {
-    injectImports: boolean;
-    ignore: boolean;
-    sourcemap: boolean;
-    chunkFileNames: string;
-    entryFileNames: string;
-}
+const inject_styles = `
+export default function(files) {
+    return Promise.all(files.map(function(file) { return new Promise(function(fulfil, reject) {
+        var href = new URL(file, import.meta.url);
+        var baseURI = document.baseURI;
 
-interface InputPluginOptions {
-    injectImports?: boolean;
-    ignore?: boolean;
-    sourcemap?: boolean;
-    chunkFileNames?: string;
-    entryFileNames?: string;
-}
+        if (!baseURI) {
+            var baseTags = document.getElementsByTagName('base');
+            baseURI = baseTags.length ? baseTags[0].href : document.URL;
+        }
 
-const cssChunks: PluginImpl<InputPluginOptions> = function (options = {}) {
+        var relative = ('' + href).substring(baseURI.length);
+        var link = document.querySelector('link[rel=stylesheet][href="' + relative + '"]')
+            || document.querySelector('link[rel=stylesheet][href="' + href + '"]');
+        if (!link) {
+            link = document.createElement('link');
+            link.rel = 'stylesheet';
+            link.href = href;
+            document.head.appendChild(link);
+        }
+        if (link.sheet) {
+            fulfil();
+        } else {
+            link.onload = function() { return fulfil() };
+            link.onerror = reject;
+        }
+    })}));
+};`.trim();
+
+const find_css = (chunk: RenderedChunk, bundle: OutputBundle) => {
+    const css_files = new Set<string>();
+    const visited = new Set<RenderedChunk>();
+
+    const recurse = (c: RenderedChunk) => {
+        if (visited.has(c)) return;
+        visited.add(c);
+
+        if (c.imports) {
+            c.imports.forEach(file => {
+                if (file.endsWith('.css')) {
+                    css_files.add(file);
+                } else {
+                    const imported_chunk = <OutputChunk>bundle[file];
+                    if (imported_chunk) {
+                        recurse(imported_chunk);
+                    }
+                }
+            });
+        }
+    };
+
+    recurse(chunk);
+    return Array.from(css_files);
+};
+
+const cssChunks: PluginImpl<InputPluginOptions> = function(options = {}) {
     const filter = createFilter(/\.css$/i, []);
 
     const defaultPluginOptions: PluginOptions = {
         injectImports: false,
+        injectType: null,
         ignore: false,
         sourcemap: false,
         chunkFileNames: '[name]-[hash].css',
@@ -69,6 +131,41 @@ const cssChunks: PluginImpl<InputPluginOptions> = function (options = {}) {
 
     return {
         name: 'css',
+
+        buildStart(this: PluginContext): void {
+            if (!pluginOptions.injectType) {
+                return;
+            }
+
+            this.emitFile({
+                type: 'chunk',
+                id: INJECT_STYLES_ID,
+                name: INJECT_STYLES_NAME,
+                preserveSignature: 'allow-extension'
+            });
+        },
+
+        load(id: string) {
+            return id === INJECT_STYLES_ID ? inject_styles : null;
+        },
+
+        resolveId(importee: string) {
+            return importee === INJECT_STYLES_ID ? INJECT_STYLES_ID : null;
+        },
+
+        renderDynamicImport({ targetModuleId }) {
+            if (pluginOptions.injectType && targetModuleId) {
+                return {
+                    left: 'Promise.all([import(',
+                    right: `), ___CSS_INJECTION___${Buffer.from(targetModuleId).toString('hex')}___]).then(function(x) { return x[0]; })`
+                };
+            } else {
+                return {
+                    left: 'import(',
+                    right: ')'
+                };
+            }
+        },
 
         transform(code: string, id: string) {
             if (!filter(id)) return null;
@@ -172,6 +269,45 @@ const cssChunks: PluginImpl<InputPluginOptions> = function (options = {}) {
                 });
 
                 chunk.imports.push(css_file_name);
+            }
+
+            if (!pluginOptions.injectType) {
+                return;
+            }
+            const inject_styles_file = Object.keys(bundle).find(f => f.startsWith('inject_styles'));
+
+            let has_css = false;
+            for (const name in bundle) {
+                const chunk = <OutputChunk>bundle[name];
+
+                let chunk_has_css = false;
+
+                if (chunk.code) {
+                    chunk.code = chunk.code.replace(/___CSS_INJECTION___([0-9a-f]+)___/g, (m, id) => {
+                        id = Buffer.from(id, 'hex').toString();
+                        const target = <OutputChunk>Object.values(bundle)
+                            .find(c => (<OutputChunk>c).modules && (<OutputChunk>c).modules[id]);
+
+                        if (target) {
+                            const css_files = find_css(target, bundle);
+                            if (css_files.length > 0) {
+                                chunk_has_css = true;
+                                return `__inject_styles(${JSON.stringify(css_files)})`;
+                            }
+                        }
+
+                        return '';
+                    });
+
+                    if (chunk_has_css) {
+                        has_css = true;
+                        chunk.code = `import __inject_styles from './${inject_styles_file}';\n` + chunk.code;
+                    }
+                }
+            }
+
+            if (inject_styles_file && !has_css) {
+                delete bundle[inject_styles_file];
             }
         }
     };


### PR DESCRIPTION
Closes https://github.com/domingues/rollup-plugin-css-chunks/issues/4

I made the new `injectType` option an enum that's either `null` or `'link'` right now. Potentially it could be extended further in the future with additional options like Webpack's `style-loader` `injectType`