### PR TITLE
Fix peerDependencies specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # rollup-plugin-css-chunks changelog
 
+## 2.0.2 (10/12/2020)
+
+* fix: peerDependencies specification (#17);
+
 ## 2.0.1 (07/12/2020)
 
 * fix: url-join missing from dependencies (#13);

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
     "eslint": "^7.9.0",
-    "rollup": "^2.27.0",
+    "rollup": "^2.29.0",
     "typescript": "^4.0.2"
   },
   "peerDependencies": {
-    "rollup": ">=1.19.0 <2.0.0 || >=2.21.0"
+    "rollup": ">=2.29.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-css-chunks",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Rollup plugin to extract CSS into chunks",
   "main": "index.js",
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2020",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "es2019",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
Closes https://github.com/domingues/rollup-plugin-css-chunks/issues/15

`meta` is not available until 2.29.0: https://github.com/rollup/rollup/releases/tag/v2.29.0

I'm not quite sure how you were even building the library as `npm run build` would not complete successfully for me without this PR